### PR TITLE
Upgrade the buffer processing to deal with latest node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "texas",
 	"description": "Texas Hold'em hand evaluator for node.js.",
 	"homepage": "http://decs.github.com/texas/",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"author": {
 		"name": "André Costa",
 		"email": "andrecosta90@gmail.com"
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"underscore": ">= 1.4.x",
-		"memcpy": "^0.6.0",
+		"memcpy": "^0.6.0"
 	},
 	"engines": {
 		"node": ">= 0.8.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"underscore": ">= 1.4.x",
-		"compress-buffer": ">= 1.1.x"
+		"memcpy": "^0.6.0",
 	},
 	"engines": {
 		"node": ">= 0.8.0"

--- a/texas.js
+++ b/texas.js
@@ -5,7 +5,8 @@
 var _ = require('underscore');
 var fs = require('fs');
 var crypto = require('crypto');
-var gzip = require('compress-buffer');
+var zlib = require('zlib');
+var memcpy = require('memcpy');
 
 // ## Definitions
 

--- a/texas.js
+++ b/texas.js
@@ -30,7 +30,10 @@ var hands = ['Invalid', 'High Card', 'One Pair', 'Two Pairs',
 
 // Loads the look-up table.
 var buffer = fs.readFileSync(__dirname + '/HandRanks.dat.gz');
-var evaluator = new Int32Array(gzip.uncompress(buffer));
+var zbuffer = zlib.gunzipSync(buffer);
+var bufferArray = new ArrayBuffer(zbuffer.length);
+memcpy(bufferArray,0,zbuffer);
+var evaluator = new Int32Array(bufferArray);
 
 // ## Internal Functions
 


### PR DESCRIPTION
This allows the the texas npm module to work in the latest versions of node which no longer supports the compress-buffer module.
